### PR TITLE
Update langstream.md to use PNG

### DIFF
--- a/_staff_members/langstream.md
+++ b/_staff_members/langstream.md
@@ -1,7 +1,7 @@
 ---
 name: LangStream
 position: Developer
-image_path: /images/logo.svg
+image_path: /images/logo.png
 twitter: https://twitter.com/langstream_ai
 blurb: 
 ---


### PR DESCRIPTION
The feature that pulls author info from staff_members is not compatible with SVG files, so changing to PNG.